### PR TITLE
improve perf

### DIFF
--- a/src/asset.js
+++ b/src/asset.js
@@ -9,14 +9,9 @@ class InterpolateHtmlAsset extends HTMLAsset {
 
     interpolate(code) {
         const env = this.options.env;
-        Object.keys(env).forEach((envKey) => {
-            const replacement = env[envKey];
-            code = code.replace(
-                new RegExp('%' + escapeStringRegexp(envKey) + '%', 'g'),
-                replacement,
-            )
-        });
-        return code;
+        const regex = /%(\w.*?)%/g;
+        
+        return code.replace(regex, (match, envKey) => env[envKey] === undefined ? match : env[envKey]);
     }
 }
 


### PR DESCRIPTION
rather than loop over all env vars (and build a regex from each), instead, search for interpolations with one regex and use the capture to find the value in the env vars

if the env var is `undefined`, do not replace the interpolation (leave '%' characters and var name in place) which should make this change backwards compatible and not require a major version bump :)